### PR TITLE
add support for creating additional users from config files

### DIFF
--- a/charts/clickhouse/README.md.gotmpl
+++ b/charts/clickhouse/README.md.gotmpl
@@ -92,6 +92,53 @@ clickhouse:
     secretName: "clickhouse-auth" # Must contain keys: username, password
 ```
 
+### Additional User Configuration
+
+Define extra ClickHouse users beyond the primary authentication user.
+Supports both YAML and XML formats.
+
+```yaml
+clickhouse:
+  additionalUsers:
+    # Secret key containing the user config file (YAML or XML)
+    # The file extension should match the format, e.g.:
+    #   - extra-users.yaml for YAML
+    #   - extra-users.xml for XML
+    secretKey: extra-users.yaml
+
+    # Option 1: Inline configuration (YAML or XML)
+    # Example (YAML):
+    content: |
+      users:
+        analytics:
+          password: "analystpass"
+          profile: readonly
+          quota: default
+
+    # Example (XML):
+    content: |
+      <clickhouse>
+        <users>
+          <analytics>
+            <password>analystpass</password>
+            <profile>readonly</profile>
+            <quota>default</quota>
+          </analytics>
+        </users>
+      </clickhouse>
+
+    # Option 2: Existing secret (takes precedence over inline content)
+    existingSecret: "clickhouse-additional-users"
+```
+
+> [!NOTE]
+> Files in `/etc/clickhouse-server/users.d/` are loaded alphabetically;
+> `default-user.xml` from the base image is loaded first, so the secretKey should be named to apply afterward.
+
+> [!NOTE]
+> ClickHouse recommends using a [SQL-driven access management workflow](https://clickhouse.com/docs/operations/access-rights) (roles, users, and quotas managed via SQL) instead of configuration files.
+> This can be enabled by setting `clickhouse.auth.accessManagement=true` in the values file.
+
 ### Interserver Authentication
 
 Secure communication between ClickHouse nodes in a cluster.

--- a/charts/clickhouse/templates/_helpers.tpl
+++ b/charts/clickhouse/templates/_helpers.tpl
@@ -129,6 +129,17 @@ ClickHouse Init DB Secret name
 {{- end }}
 
 {{/*
+ClickHouse additional users secret name
+*/}}
+{{- define "clickhouse.usersdSecretName" -}}
+{{- if .Values.clickhouse.additionalUsers.secretName }}
+{{- .Values.clickhouse.additionalUsers.secretName }}
+{{- else }}
+{{- printf "%s-additional-users" (include "clickhouse.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
 Default pod anti-affinity for Keeper
 */}}
 {{- define "clickhouse.keeperPodAntiAffinity" -}}

--- a/charts/clickhouse/templates/clickhouse-statefulset.yaml
+++ b/charts/clickhouse/templates/clickhouse-statefulset.yaml
@@ -114,10 +114,15 @@ spec:
               containerPort: {{ $.Values.ports.clickhouse.metrics }}
             {{- end }}
           volumeMounts:
-            - name: config
-              mountPath: /etc/clickhouse-server/config.d
             - name: data
               mountPath: /var/lib/clickhouse
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d
+            {{- if or $.Values.clickhouse.additionalUsers.content $.Values.clickhouse.additionalUsers.existingSecret }}
+            - name: usersd
+              mountPath: /etc/clickhouse-server/users.d/{{ $.Values.clickhouse.additionalUsers.secretKey }}
+              subPath: {{ $.Values.clickhouse.additionalUsers.secretKey }}
+            {{- end }}
             {{- if or $.Values.clickhouse.initdb.scripts $.Values.clickhouse.initdb.existingSecret }}
             - name: initdb
               mountPath: /docker-entrypoint-initdb.d
@@ -146,6 +151,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "clickhouse.fullname" $ }}-config
+        {{- if or $.Values.clickhouse.additionalUsers.content $.Values.clickhouse.additionalUsers.existingSecret }}
+        - name: usersd
+          secret:
+            secretName: {{ include "clickhouse.usersdSecretName" $ }}
+        {{- end }}
         {{- if or $.Values.clickhouse.initdb.scripts $.Values.clickhouse.initdb.existingSecret }}
         - name: initdb
           secret:

--- a/charts/clickhouse/templates/clickhouse-usersd-secret.yaml
+++ b/charts/clickhouse/templates/clickhouse-usersd-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (not .Values.clickhouse.additionalUsers.existingSecret) .Values.clickhouse.additionalUsers.content }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clickhouse.usersdSecretName" . }}
+  labels:
+    {{- include "clickhouse.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+type: Opaque
+data:
+  {{ .Values.clickhouse.additionalUsers.secretKey }}: {{ .Values.clickhouse.additionalUsers.content | b64enc }}
+{{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -224,6 +224,22 @@ clickhouse:
     # @section -- ClickHouse Configuration
     annotations: {}
 
+  # Additional user configuration
+  additionalUsers:
+    # -- Use an existing Secret containing the user config file
+    # Takes precedence over `content`
+    # @section -- Authentication
+    existingSecret: ""
+
+    # -- Key in the Secret that contains the user config (YAML or XML)
+    # Determines the filename under `/etc/clickhouse-server/users.d/`
+    # @section -- Authentication
+    secretKey: "extra-users.yaml"
+
+    # -- Inline user configuration (YAML or XML)
+    # @section -- Authentication
+    content: ""
+
   # -- Custom ClickHouse configuration.
   # This will be merged with the default configuration.
   # @section -- ClickHouse Configuration


### PR DESCRIPTION
## Additional User Configuration

Define extra ClickHouse users beyond the primary authentication user.
Supports both YAML and XML formats.

```yaml
clickhouse:
  additionalUsers:
    # Secret key containing the user config file (YAML or XML)
    # The file extension should match the format, e.g.:
    #   - extra-users.yaml for YAML
    #   - extra-users.xml for XML
    secretKey: extra-users.yaml

    # Option 1: Inline configuration (YAML or XML)
    # Example (YAML):
    content: |
      users:
        analytics:
          password: "analystpass"
          profile: readonly
          quota: default

    # Example (XML):
    content: |
      <clickhouse>
        <users>
          <analytics>
            <password>analystpass</password>
            <profile>readonly</profile>
            <quota>default</quota>
          </analytics>
        </users>
      </clickhouse>

    # Option 2: Existing secret (takes precedence over inline content)
    existingSecret: "clickhouse-additional-users"
```

> [!NOTE]
> Files in `/etc/clickhouse-server/users.d/` are loaded alphabetically;
> `default-user.xml` from the base image is loaded first, so the secretKey should be named to apply afterward.

> [!NOTE]
> ClickHouse recommends using a [SQL-driven access management workflow](https://clickhouse.com/docs/operations/access-rights) (roles, users, and quotas managed via SQL) instead of configuration files.
> This can be enabled by setting `clickhouse.auth.accessManagement=true` in the values file.

Closes #15 