### PR TITLE
fix issue where secret keys and values may persist after changes

### DIFF
--- a/charts/clickhouse/templates/clickhouse-auth-secret.yaml
+++ b/charts/clickhouse/templates/clickhouse-auth-secret.yaml
@@ -10,9 +10,9 @@ metadata:
     {{- include "clickhouse.labels" . | nindent 4 }}
     app.kubernetes.io/component: clickhouse
 type: Opaque
-stringData:
-  username: {{ $username | quote }}
-  password: {{ $password | quote }}
+data:
+  username: {{ $username | b64enc }}
+  password: {{ $password | b64enc }}
 {{- else }}
 {{- fail "Username and password must be provided when ClickHouse auth is enabled and createSecret is true" }}
 {{- end }}

--- a/charts/clickhouse/templates/clickhouse-initdb-secret.yaml
+++ b/charts/clickhouse/templates/clickhouse-initdb-secret.yaml
@@ -7,9 +7,8 @@ metadata:
     {{- include "clickhouse.labels" . | nindent 4 }}
     app.kubernetes.io/component: clickhouse
 type: Opaque
-stringData:
+data:
   {{- range $key, $value := .Values.clickhouse.initdb.scripts }}
-  {{ $key }}: |
-    {{- $value | nindent 4 }}
+  {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/clickhouse/templates/clickhouse-interserver-secret.yaml
+++ b/charts/clickhouse/templates/clickhouse-interserver-secret.yaml
@@ -10,9 +10,9 @@ metadata:
     {{- include "clickhouse.labels" . | nindent 4 }}
     app.kubernetes.io/component: clickhouse
 type: Opaque
-stringData:
-  username: {{ $username | quote }}
-  password: {{ $password | quote }}
+data:
+  username: {{ $username | b64enc }}
+  password: {{ $password | b64enc }}
 {{- else }}
 {{- fail "Username and password must be provided when interserver auth is enabled and createSecret is true" }}
 {{- end }}

--- a/charts/clickhouse/templates/keeper-auth-secret.yaml
+++ b/charts/clickhouse/templates/keeper-auth-secret.yaml
@@ -10,8 +10,8 @@ metadata:
     {{- include "clickhouse.labels" . | nindent 4 }}
     app.kubernetes.io/component: keeper
 type: Opaque
-stringData:
-  {{ .Values.keeper.auth.secretKey }}: {{ printf "%s:%s" $username $password | quote }}
+data:
+  {{ .Values.keeper.auth.secretKey }}: {{ printf "%s:%s" $username $password | b64enc }}
 {{- else }}
 {{- fail "Username and password must be provided when Keeper auth is enabled and createSecret is true" }}
 {{- end }}


### PR DESCRIPTION
Use data instead of stringData in secrets to fix issue where old secretKeys and values would persist after helm chart upgrades if the secretKey was changed.