### PR TITLE
update s3 storage docs and add cluster macro

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: clickhouse
-version: 0.3.3
+version: 0.3.4
 appVersion: 25.11.2-alpine
 description: A Helm chart for deploying ClickHouse with optional ClickHouse Keeper
 type: application

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying ClickHouse with optional ClickHouse Keeper
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.11.2-alpine](https://img.shields.io/badge/AppVersion-25.11.2--alpine-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.11.2-alpine](https://img.shields.io/badge/AppVersion-25.11.2--alpine-informational?style=flat-square)
 
 ## Features
 
@@ -39,8 +39,15 @@ clickhouse:
 
   storageConfiguration:
     enabled: true
-    s3Endpoint: https://bucket-name.s3.region-name.amazonaws.com/path/
+    s3Endpoint: https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/
 ```
+
+> [!TIP]
+> Including `{cluster}`, `{shard}`, and `{replica}` placeholders in the
+> S3 endpoint is recommended. These placeholders are automatically replaced by
+> ClickHouse macros at runtime, ensuring that each shard and replica writes to a
+> unique path while all data belonging to the same cluster is organized under the
+> cluster name.
 
 The S3 configuration assumes credentials are available through the pod's environment (instance profile, environment variables, etc.). For other authentication methods, customize the configTemplate:
 
@@ -48,7 +55,7 @@ The S3 configuration assumes credentials are available through the pod's environ
 clickhouse:
   storageConfiguration:
     enabled: true
-    s3Endpoint: https://bucket-name.s3.region-name.amazonaws.com/path/
+    s3Endpoint: https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/
 
     configTemplate: |
       disks:
@@ -251,7 +258,7 @@ clickhouse:
   defaultStoragePolicy: s3_with_cache
   storageConfiguration:
     enabled: true
-    s3Endpoint: "https://bucket-name.s3.region-name.amazonaws.com/data/"
+    s3Endpoint: "https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/"
 
   # Local persistent storage for metadata and cache
   persistentVolume:
@@ -341,7 +348,7 @@ keeper:
 | clickhouse.persistentVolume.storageClass | string | `""` | Storage class to use for persistent volumes (uses default if empty) |
 | clickhouse.storageConfiguration.configTemplate | string | See Values | Custom storage configuration template. Configures disks and storage policies for ClickHouse. |
 | clickhouse.storageConfiguration.enabled | bool | `false` | Enable custom storage configuration (S3, etc.) |
-| clickhouse.storageConfiguration.s3Endpoint | string | `nil` | S3-compatible storage endpoint URL. Example: `https://BUCKET.s3.REGION.amazonaws.com/PATH/` |
+| clickhouse.storageConfiguration.s3Endpoint | string | `nil` | S3-compatible storage endpoint URL. Example: `https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/` |
 | keeper.persistentVolume.enabled | bool | `true` | Enable persistent storage for Keeper |
 | keeper.persistentVolume.size | string | `"1Gi"` | Size of persistent volume for Keeper data |
 | keeper.persistentVolume.storageClass | string | `""` | Storage class to use (uses default if empty) |

--- a/charts/clickhouse/README.md.gotmpl
+++ b/charts/clickhouse/README.md.gotmpl
@@ -39,8 +39,16 @@ clickhouse:
 
   storageConfiguration:
     enabled: true
-    s3Endpoint: https://bucket-name.s3.region-name.amazonaws.com/path/
+    s3Endpoint: https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/
 ```
+
+> [!TIP]
+> Including `{cluster}`, `{shard}`, and `{replica}` placeholders in the
+> S3 endpoint is recommended. These placeholders are automatically replaced by
+> ClickHouse macros at runtime, ensuring that each shard and replica writes to a
+> unique path while all data belonging to the same cluster is organized under the
+> cluster name.
+
 
 The S3 configuration assumes credentials are available through the pod's environment (instance profile, environment variables, etc.). For other authentication methods, customize the configTemplate:
 
@@ -48,7 +56,7 @@ The S3 configuration assumes credentials are available through the pod's environ
 clickhouse:
   storageConfiguration:
     enabled: true
-    s3Endpoint: https://bucket-name.s3.region-name.amazonaws.com/path/
+    s3Endpoint: https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/
 
     configTemplate: |
       disks:
@@ -251,7 +259,7 @@ clickhouse:
   defaultStoragePolicy: s3_with_cache
   storageConfiguration:
     enabled: true
-    s3Endpoint: "https://bucket-name.s3.region-name.amazonaws.com/data/"
+    s3Endpoint: "https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/"
 
   # Local persistent storage for metadata and cache
   persistentVolume:

--- a/charts/clickhouse/templates/clickhouse-configmap.yaml
+++ b/charts/clickhouse/templates/clickhouse-configmap.yaml
@@ -8,6 +8,7 @@ metadata:
 data:
   00-default-config.yaml: |
     macros:
+      cluster: {{ .Values.clickhouse.clusterName }}
       replica:
         '@from_env': CLICKHOUSE_REPLICA_ID
       shard:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -128,7 +128,7 @@ clickhouse:
     # @section -- Storage
     enabled: false
     # -- S3-compatible storage endpoint URL.
-    # Example: `https://BUCKET.s3.REGION.amazonaws.com/PATH/`
+    # Example: `https://mybucket.s3.myregion.amazonaws.com/clickhouse/{cluster}/{shard}/{replica}/`
     # @section -- Storage
     s3Endpoint: ~
     # -- Custom storage configuration template.


### PR DESCRIPTION
- Add clusterName to ClickHouse macro config to support var substitution in the s3Endpoint
- Update s3 storage docs and add tip about macro usage in the s3Endpoint