### PR TITLE
fix env var used to enable sql access management

### DIFF
--- a/charts/clickhouse/templates/clickhouse-statefulset.yaml
+++ b/charts/clickhouse/templates/clickhouse-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "clickhouse.authSecretName" $ }}
                   key: password
-            - name: CLICKHOUSE_ACCESS_MANAGEMENT
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: {{ $.Values.clickhouse.auth.accessManagement | ternary "1" "0" | quote }}
             {{- if $.Values.clickhouse.auth.skipUserSetup }}
             - name: CLICKHOUSE_SKIP_USER_SETUP


### PR DESCRIPTION
Update SQL access management env var from `CLICKHOUSE_ACCESS_MANAGEMENT` to `CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT `.

Closes #32 