### PR TITLE
chore(keeper): Allow custom labels on keeper auth setup Job

### DIFF
--- a/charts/clickhouse/templates/keeper-auth-job.yaml
+++ b/charts/clickhouse/templates/keeper-auth-job.yaml
@@ -19,6 +19,9 @@ spec:
     metadata:
       labels:
         {{- include "clickhouse.selectorLabels" . | nindent 8 }}
+        {{- if .Values.keeper.auth.setup.labels }}
+          {{- .Values.keeper.auth.setup.labels | toYaml | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/component: keeper-auth-setup
     spec:
       restartPolicy: OnFailure

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -332,6 +332,8 @@ keeper:
       # @ignored
       nodeSelector: {}
       # @ignored
+      labels: {}
+      # @ignored
       affinity: {}
       # @ignored
       tolerations: []


### PR DESCRIPTION
## Summary
- Adds optional user-defined labels to the Keeper auth setup Kubernetes Job’s pod template labels.
    - This is particularly useful in an istio service mesh environment where you want Clickhouse to be a part of the mesh but want to avoid having an istio sidecar attached to your job indefinitely. (https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy)
- Tested locally w/ helm templates successfully but happy to add these to the `test-values.yaml` if that is preferred

## Test Example
### Auth enabled w/ labels
values-override.yaml:
```
keeper:
  enabled: true
  auth:
    enabled: true
    password: some-password
    username: some-username
    setup:
      labels:
        sidecar.istio.io/inject: "false"
```

job.yaml (Through `spec.template.metadata.labels`)
```
# Source: clickhouse/templates/keeper-auth-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-clickhouse-keeper-auth-setup
  labels:
    helm.sh/chart: clickhouse-0.3.9
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "25.12.4-alpine"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: keeper-auth-setup
spec:
  backoffLimit: 6
  ttlSecondsAfterFinished: 3600
  activeDeadlineSeconds: 600
  template:
    metadata:
      labels:
        app.kubernetes.io/name: clickhouse
        app.kubernetes.io/instance: release-name
        sidecar.istio.io/inject: "false"
        app.kubernetes.io/component: keeper-auth-setup
    spec:
       ...
```

### Auth enabled w/o labels
values-override.yaml:
```
keeper:
  enabled: true
  auth:
    enabled: true
    password: some-password
    username: some-username
```

job.yaml (Through `spec.template.metadata.labels`)
```
# Source: clickhouse/templates/keeper-auth-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-clickhouse-keeper-auth-setup
  labels:
    helm.sh/chart: clickhouse-0.3.9
    app.kubernetes.io/name: clickhouse
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "25.12.4-alpine"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: keeper-auth-setup
spec:
  backoffLimit: 6
  ttlSecondsAfterFinished: 3600
  activeDeadlineSeconds: 600
  template:
    metadata:
      labels:
        app.kubernetes.io/name: clickhouse
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/component: keeper-auth-setup
    spec:
      ...
```