### PR TITLE
feat(chart): add pod spec enhancements for graceful shutdown and scheduling

### DIFF
--- a/charts/clickhouse/templates/clickhouse-statefulset.yaml
+++ b/charts/clickhouse/templates/clickhouse-statefulset.yaml
@@ -37,10 +37,17 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/clickhouse-configmap.yaml") $ | sha256sum }}
+        {{- if and (not $.Values.clickhouse.initdb.existingSecret) $.Values.clickhouse.initdb.scripts }}
+        checksum/initdb: {{ include (print $.Template.BasePath "/clickhouse-initdb-secret.yaml") $ | sha256sum }}
+        {{- end }}
         {{- with $.Values.clickhouse.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ $.Values.clickhouse.terminationGracePeriodSeconds }}
+      {{- with $.Values.clickhouse.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       serviceAccountName: {{ include "clickhouse.serviceAccountName" $ }}
       {{- with $.Values.clickhouse.securityContext }}
       securityContext:
@@ -151,6 +158,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml $.Values.clickhouse.resources | nindent 12 }}
+          {{- with $.Values.clickhouse.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $.Values.clickhouse.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}
@@ -169,6 +180,10 @@ spec:
       {{- end }}
       affinity:
         {{- include "clickhouse.podAntiAffinity" (dict "context" $ "shard" $shard) | nindent 8 }}
+      {{- with $.Values.clickhouse.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $.Values.clickhouse.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/clickhouse/templates/keeper-statefulset.yaml
+++ b/charts/clickhouse/templates/keeper-statefulset.yaml
@@ -36,6 +36,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.keeper.terminationGracePeriodSeconds }}
+      {{- with .Values.keeper.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       serviceAccountName: {{ include "clickhouse.keeperServiceAccountName" . }}
       {{- with .Values.keeper.securityContext }}
       securityContext:
@@ -74,6 +78,10 @@ spec:
               mountPath: /var/lib/clickhouse
           resources:
             {{- toYaml .Values.keeper.resources | nindent 12 }}
+          {{- with .Values.keeper.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.keeper.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}
@@ -100,6 +108,10 @@ spec:
       {{- end }}
       affinity:
         {{- include "clickhouse.keeperPodAntiAffinity" . | nindent 8 }}
+      {{- with .Values.keeper.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.keeper.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -180,6 +180,20 @@ clickhouse:
   # @section -- ClickHouse Configuration
   affinity: {}
 
+  # -- Topology spread constraints for ClickHouse pods
+  # @section -- ClickHouse Configuration
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/component: clickhouse
+
+  # -- Priority class name for ClickHouse pods
+  # @section -- ClickHouse Configuration
+  priorityClassName: ""
+
   # PodDisruptionBudget configuration for ClickHouse
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for ClickHouse
@@ -211,6 +225,20 @@ clickhouse:
       type: RollingUpdate
       # -- Partition for rolling update (pods with ordinal >= partition are updated)
       # partition: 0
+
+  # -- Seconds Kubernetes waits for the pod to terminate gracefully before sending SIGKILL.
+  # @section -- ClickHouse Configuration
+  terminationGracePeriodSeconds: 30
+
+  # -- Lifecycle hooks for the ClickHouse container
+  # @section -- ClickHouse Configuration
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - bash
+    #       - -c
+    #       - "clickhouse-client --query 'SYSTEM STOP MERGES' && sleep 10"
 
   # @ignored
   startupProbe: {}
@@ -436,6 +464,20 @@ keeper:
   # @section -- Keeper Configuration
   affinity: {}
 
+  # -- Topology spread constraints for Keeper pods
+  # @section -- Keeper Configuration
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       app.kubernetes.io/component: keeper
+
+  # -- Priority class name for Keeper pods
+  # @section -- Keeper Configuration
+  priorityClassName: ""
+
   # PodDisruptionBudget configuration for Keeper
   podDisruptionBudget:
     # -- Enable PodDisruptionBudget for Keeper
@@ -467,6 +509,20 @@ keeper:
       type: RollingUpdate
       # -- Partition for rolling update (pods with ordinal >= partition are updated)
       # partition: 0
+
+  # -- Seconds Kubernetes waits for the pod to terminate gracefully before sending SIGKILL.
+  # @section -- Keeper Configuration
+  terminationGracePeriodSeconds: 30
+
+  # -- Lifecycle hooks for the Keeper container
+  # @section -- Keeper Configuration
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - bash
+    #       - -c
+    #       - "sleep 5"
 
   # @ignored
   startupProbe: {}


### PR DESCRIPTION
## Summary
- Add `terminationGracePeriodSeconds` and `lifecycle` (preStop hook) support to both ClickHouse and Keeper StatefulSets
- Add `priorityClassName` and `topologySpreadConstraints` support to both ClickHouse and Keeper StatefulSets
- Add `checksum/initdb` annotation to ClickHouse pods for automatic rollout when init scripts change