### PR TITLE
Making the storageClass optional

### DIFF
--- a/charts/clickhouse/templates/clickhouse-statefulset.yaml
+++ b/charts/clickhouse/templates/clickhouse-statefulset.yaml
@@ -219,7 +219,9 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
+        {{- if $.Values.clickhouse.persistentVolume.storageClass }}
         storageClassName: {{ $.Values.clickhouse.persistentVolume.storageClass | quote }}
+        {{- end }}
         resources:
           requests:
             storage: {{ $.Values.clickhouse.persistentVolume.size | quote }}

--- a/charts/clickhouse/templates/keeper-statefulset.yaml
+++ b/charts/clickhouse/templates/keeper-statefulset.yaml
@@ -122,7 +122,9 @@ spec:
         name: data
       spec:
         accessModes: [ "ReadWriteOnce" ]
+        {{- if $.Values.keeper.persistentVolume.storageClass }}
         storageClassName: {{ .Values.keeper.persistentVolume.storageClass | quote }}
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.keeper.persistentVolume.size | quote }}


### PR DESCRIPTION
The documentation in `values.yaml` says:

> Storage class to use for persistent volumes (uses default if empty)

But this was not actually implemented. Keeping clickhouse.persistentVolume.storageClass to an empty string would generate:

```yaml
storageClassName: ""
```

which triggers errors at deploy (at least in my cluster):

> Normal  FailedBinding  104s (x102 over 26m)  persistentvolume-controller  no persistent volumes available for this claim and no storage class is set

We add a simple "if" to avoid adding the storageClassName in the StatefulSet if it is empty.

Hope this helps :)

Thanks a lot for this great Helm chart :heart: